### PR TITLE
Fixed NoisePainter3D. Replaced `grid.set_cell` with `grid.set_value`

### DIFF
--- a/addons/gaea/modifiers/3D/noise_painter_3d.gd
+++ b/addons/gaea/modifiers/3D/noise_painter_3d.gd
@@ -51,7 +51,7 @@ func _apply_area(area: AABB, grid: GaeaGrid, _generator: GaeaGenerator) -> void:
 					if not _passes_filter(grid, cell):
 						continue
 
-					grid.set_cell(cell, tile)
+					grid.set_value(cell, tile)
 
 
 func _is_out_of_bounds(cell: Vector3i) -> bool:


### PR DESCRIPTION
Let me know if this should not be changed. I found this while using Gaea for my own game, and it was bringing up errors when using noise_painter_3d, but when I switched the function call, it worked like normal.