### PR TITLE
Remove warning and allow using ChunkLoaders on a finite world

### DIFF
--- a/addons/gaea/others/chunk_loader_2d.gd
+++ b/addons/gaea/others/chunk_loader_2d.gd
@@ -44,10 +44,6 @@ func _process(delta: float) -> void:
 	if Engine.is_editor_hint() or not is_instance_valid(generator):
 		return
 
-	if generator.settings.get("infinite") == false:
-		push_warning("Generator's settings at %s has infinite disabled, can't generate chunks." % generator.name)
-		return
-
 	var current_time = Time.get_ticks_msec()
 	if current_time - _last_run > update_rate:
 		# todo make check loading

--- a/addons/gaea/others/chunk_loader_3d.gd
+++ b/addons/gaea/others/chunk_loader_3d.gd
@@ -44,10 +44,6 @@ func _process(delta: float) -> void:
 	if Engine.is_editor_hint() or not is_instance_valid(generator):
 		return
 
-	if generator.settings.get("infinite") == false:
-		push_warning("Generator's settings at %s has infinite disabled, can't generate chunks." % generator.name)
-		return
-
 	var current_time = Time.get_ticks_msec()
 	if current_time - _last_run > update_rate:
 		# todo make check loading


### PR DESCRIPTION
Not sure why this was even there, as it works just fine.