### PR TITLE
Add serialization functions

### DIFF
--- a/addons/gaea/generators/generator.gd
+++ b/addons/gaea/generators/generator.gd
@@ -73,7 +73,7 @@ func get_seed() -> int:
 	return seed
 
 
-## Returns the grid as a [PackedByteArray], allowing you to deserialize it later using [method deserialize].
+## Returns the currently generated grid as a [PackedByteArray], allowing you to deserialize it later using [method deserialize].
 func serialize() -> PackedByteArray:
 	return var_to_bytes(grid.get_grid())
 

--- a/addons/gaea/generators/generator.gd
+++ b/addons/gaea/generators/generator.gd
@@ -73,6 +73,17 @@ func get_seed() -> int:
 	return seed
 
 
+## Returns the grid as a [PackedByteArray], allowing you to deserialize it later using [method deserialize].
+func serialize() -> PackedByteArray:
+	return var_to_bytes(grid.get_grid())
+
+
+## Deserializes the [param bytes] obtained from [method serialize], setting the grid to its value.
+func deserialize(bytes: PackedByteArray):
+	grid.set_grid_serialized(bytes)
+	grid_updated.emit()
+
+
 ### Modifiers ###
 
 

--- a/addons/gaea/grid.gd
+++ b/addons/gaea/grid.gd
@@ -53,6 +53,21 @@ func set_grid(grid: Dictionary) -> void:
 	_grid = grid
 
 
+## Sets the grid to the serialized grid that [param bytes] represents. See [method GaeaGenerator.serialize] and [method GaeaGenerator.deserialize].
+func set_grid_serialized(bytes: PackedByteArray) -> void:
+	var grid = bytes_to_var(bytes)
+	if not (grid is Dictionary):
+		push_error("Attempted to deserialize invalid grid")
+		return
+
+	for layer in grid:
+		for tile in grid[layer]:
+			var object = grid[layer][tile]
+			if object is EncodedObjectAsID:
+				grid[layer][tile] = instance_from_id(object.get_object_id())
+	_grid = grid
+
+
 ## Returns the grid [Dictionary].
 func get_grid() -> Dictionary:
 	return _grid


### PR DESCRIPTION
Adds 2 functions to GaeaGenerator:
- `serialize` returns a `PackedByteArray` that represents the currently generated grid.
- `deserialize` takes these bytes and sends them to the grid.

Is this enough for serialization or should we also add functions to save for files? I feel like that should be left to the user, but if there's enough demand I'll add them.