### PR TITLE
Add air layer option in HeightmapGenerators

### DIFF
--- a/addons/gaea/generators/2D/heightmap_generator/heightmap_generator_2d.gd
+++ b/addons/gaea/generators/2D/heightmap_generator/heightmap_generator_2d.gd
@@ -104,3 +104,8 @@ func _set_grid_area(area: Rect2i) -> void:
 		for y in range(area.position.y, area.end.y):
 			if y > -height and y <= -settings.min_height:
 				grid.set_valuexy(x, y, settings.tile)
+
+			if y == -height and settings.air_layer:
+				grid.set_valuexy(x, y, null)
+
+

--- a/addons/gaea/generators/2D/heightmap_generator/heightmap_generator_2d_settings.gd
+++ b/addons/gaea/generators/2D/heightmap_generator/heightmap_generator_2d_settings.gd
@@ -17,3 +17,5 @@ extends GeneratorSettings2D
 @export var height_intensity := 20
 ## Negative values means the HeightmapGenerator will go below y=0.
 @export var min_height := 0
+## If [code]true[/code], adds a layer of air ([code]null[/code] tiles above the generated terrain.
+@export var air_layer := true

--- a/addons/gaea/generators/3D/heightmap_generator_3d/heightmap_generator_3d.gd
+++ b/addons/gaea/generators/3D/heightmap_generator_3d/heightmap_generator_3d.gd
@@ -113,3 +113,6 @@ func _set_grid_area(area: AABB) -> void:
 			for y in range(area.position.y, area.end.y):
 				if y <= height and y >= settings.min_height:
 					grid.set_valuexyz(x, y, z, settings.tile)
+
+				if y == height and settings.air_layer:
+					grid.set_valuexyz(x, y, z, null)

--- a/addons/gaea/generators/3D/heightmap_generator_3d/heightmap_generator_3d_settings.gd
+++ b/addons/gaea/generators/3D/heightmap_generator_3d/heightmap_generator_3d_settings.gd
@@ -18,6 +18,8 @@ extends GeneratorSettings3D
 @export var height_intensity := 20
 ## Negative values means the HeightmapGenerator will go below y=0.
 @export var min_height := 0
+## If [code]true[/code], adds a layer of air ([code]null[/code] tiles above the generated terrain.
+@export var air_layer := true
 @export_group("Falloff", "falloff_")
 ## Enables the usage of a [FalloffMap], which makes tiles
 ## farther away from the center be lower in the heightmap,

--- a/scenes/demos/heightmap/terraria-like_generation_settings.tres
+++ b/scenes/demos/heightmap/terraria-like_generation_settings.tres
@@ -203,6 +203,7 @@ salt = 3487287303
 enabled = true
 affected_layers = Array[int]([0])
 filter_type = 3
+filter_layers = Array[int]([])
 
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_mwtbk"]
 noise_type = 3
@@ -228,4 +229,5 @@ world_length = 128
 height_offset = 160
 height_intensity = 25
 min_height = -32
+air_layer = true
 modifiers = Array[Resource("res://addons/gaea/modifiers/2D/modifier_2d.gd")]([SubResource("Resource_pu43q"), SubResource("Resource_855mm"), SubResource("Resource_q887n"), SubResource("Resource_2w3lo"), SubResource("Resource_08u4d"), SubResource("Resource_f4y1w")])


### PR DESCRIPTION
Previously, if placing, for example, trees with the AdvancedModifier, HeightmapGenerators wouldn't have trees at their highest points, because there wasn't a set of empty tiles above. This toggle fixes that.