### PR TITLE
Produce error if GaeaRenderer doesn't have a generator assigned

### DIFF
--- a/addons/gaea/renderers/2D/tilemap_gaea_renderer.gd
+++ b/addons/gaea/renderers/2D/tilemap_gaea_renderer.gd
@@ -32,6 +32,12 @@ enum NodeType {
 
 func _ready() -> void:
 	super()
+	
+	# generators are always required here, this warning serves purpose for both tilemap types
+	if !generator:
+		push_error("TilemapGaeaRenderer needs a GaeaGenerator node assigned in its exports.")
+		return
+	
 	match node_type:
 		NodeType.TILEMAP:
 			if not is_instance_valid(tile_map):

--- a/addons/gaea/renderers/3D/gridmap_gaea_renderer.gd
+++ b/addons/gaea/renderers/3D/gridmap_gaea_renderer.gd
@@ -12,6 +12,11 @@ extends GaeaRenderer3D
 
 func _ready() -> void:
 	super()
+
+    if !generator:
+		push_error("GridmapGaeaRenderer needs a GaeaGenerator node assigned in its exports.")
+		return
+
 	if grid_map.cell_size * grid_map.scale != generator.tile_size:
 		push_warning("GridMap's cell size doesn't match with generator's tile size, can cause generation issues.
 					The generator's tile size has been set to the GridMap's cell size.")


### PR DESCRIPTION
When the tilemap rendere does not have a generator assigned, this produces a low level error. Its best to warn users explicitely, as per usual, of the missing implementation.