### PR TITLE
Removed unnecessary guard in GenerateBorders.gd

### DIFF
--- a/addons/gaea/modifiers/2D/generate_borders.gd
+++ b/addons/gaea/modifiers/2D/generate_borders.gd
@@ -19,12 +19,6 @@ var _temp_grid: GaeaGrid
 
 
 func apply(grid: GaeaGrid, generator: GaeaGenerator) -> void:
-	# Check if the generator has a "settings" variable and if those
-	# settings have a "tile" variable.
-	if not generator.get("settings") or not generator.settings.get("tile"):
-		push_warning("GenerateBorder modifier not compatible with %s" % generator.name)
-		return
-
 	_temp_grid = grid.clone()
 
 	_generate_border_walls(grid)


### PR DESCRIPTION
Fixes #181 

There was a guard in the generate borders class that was unnecessary; it was guarding "generator.settings" and "generator.settings.tile" in the Apply method, even though the class doesn't actually use either of those (it merely checks for empty spaces in the tile data). Presumably this was a leftover similar to the guard used in Walls.gd.