### PR TITLE
Fixed the Getting Started Link in walker.md

### DIFF
--- a/docs/generators/walker.md
+++ b/docs/generators/walker.md
@@ -6,4 +6,4 @@ The **Walker Generator** utilizes the principle of random walks to create intric
 
 ## Tutorials
 
-- [Getting Started](/tutorials/getting_started.md)
+- [Getting Started](../tutorials/getting_started.md)


### PR DESCRIPTION
Fixes #171 

The link was not relative to the source file, as it should have been.