### PR TITLE
Pattern Support

### DIFF
--- a/addons/gaea/generators/2D/generator_2d.gd
+++ b/addons/gaea/generators/2D/generator_2d.gd
@@ -13,6 +13,7 @@ extends GaeaGenerator
 ## [b]Note:[/b] Using modifiers instead of multiple generators is recommended. Only chain generators if necessary.
 @export var next_pass: GaeaGenerator2D
 
+var tile_pool:Array[TilemapTileInfo]
 
 func _ready() -> void:
 	grid = GaeaGrid2D.new()

--- a/addons/gaea/modifiers/2D/pattern_unroll.gd
+++ b/addons/gaea/modifiers/2D/pattern_unroll.gd
@@ -16,14 +16,21 @@ func apply(grid: GaeaGrid, generator: GaeaGenerator) -> void:
 	
 	_temp_grid = grid.clone()
 
+	# For each coord in the affected layers...
 	for layer in affected_layers:
 		for coord in grid.get_cells(layer):
 			var tile_info:TilemapTileInfo = grid.get_value(coord, layer)
+			# Ignore invalid tiles...
+			if not _passes_filter(grid, coord):
+				return
+			# Find patterns...
 			if tile_info.type == TilemapTileInfo.Type.PATTERN:
 				if tile_set.get_patterns_count() > tile_info.pattern_idx:
 					var pattern:TileMapPattern = tile_set.get_pattern(tile_info.pattern_idx)
+					# And for each pattern cell...
 					for cell in pattern.get_used_cells():
 						var new_info:TilemapTileInfo = _get_from_pool(cell, pattern, tile_info, generator)
+						# Set the corresponding grid cell!
 						_temp_grid.set_value(coord + cell + tile_info.pattern_offset, new_info, layer)
 	
 	generator.grid = _temp_grid.clone()

--- a/addons/gaea/modifiers/2D/pattern_unroll.gd
+++ b/addons/gaea/modifiers/2D/pattern_unroll.gd
@@ -1,0 +1,55 @@
+@tool
+@icon("generate_borders.svg")
+class_name UnrollPatterns
+extends Modifier2D
+
+@export var tile_set : TileSet
+
+var _temp_grid: GaeaGrid
+
+func apply(grid: GaeaGrid, generator: GaeaGenerator) -> void:
+	# Check if the generator has a "settings" variable and if those
+	# settings have a "tile" variable.
+	if not generator.get("settings") or not generator.settings.get("tile"):
+		push_warning("GenerateBorder modifier not compatible with %s" % generator.name)
+		return
+	
+	_temp_grid = grid.clone()
+
+	for layer in affected_layers:
+		for coord in grid.get_cells(layer):
+			var tile_info:TilemapTileInfo = grid.get_value(coord, layer)
+			if tile_info.type == TilemapTileInfo.Type.PATTERN:
+				if tile_set.get_patterns_count() > tile_info.pattern_idx:
+					var pattern:TileMapPattern = tile_set.get_pattern(tile_info.pattern_idx)
+					for cell in pattern.get_used_cells():
+						var new_info:TilemapTileInfo = _get_from_pool(cell, pattern, tile_info, generator)
+						_temp_grid.set_value(coord + cell + tile_info.pattern_offset, new_info, layer)
+	
+	generator.grid = _temp_grid.clone()
+	_temp_grid.unreference()
+
+func _get_from_pool(cell:Vector2i, pattern:TileMapPattern, tile_info:TilemapTileInfo, generator:GaeaGenerator2D):
+	var tile_layer = tile_info.tilemap_layer
+	var alt_tile = pattern.get_cell_alternative_tile(cell)
+	var atlas = pattern.get_cell_atlas_coords(cell)
+	var source = pattern.get_cell_source_id(cell)
+	
+	for tile in generator.tile_pool:
+		var valid_layer = tile.tilemap_layer == tile_layer
+		var valid_alt = tile.alternative_tile == alt_tile
+		var valid_atlas = tile.atlas_coord == atlas
+		var valid_source = tile.source_id == source
+		var valid_id = tile.id == tile_info.id
+		if valid_layer and valid_alt and valid_atlas and valid_source and valid_id:
+			return tile
+	
+	var new_info:TilemapTileInfo = TilemapTileInfo.new()
+	new_info.tilemap_layer = tile_layer
+	new_info.alternative_tile = alt_tile
+	new_info.atlas_coord = atlas
+	new_info.source_id = source
+	new_info.id = tile_info.id
+	generator.tile_pool.append(new_info)
+	
+	return new_info

--- a/addons/gaea/modifiers/2D/walls.gd
+++ b/addons/gaea/modifiers/2D/walls.gd
@@ -24,10 +24,17 @@ func apply(grid: GaeaGrid, generator: GaeaGenerator):
 			if not _passes_filter(grid, cell):
 				continue
 
-			if grid.get_value(cell, layer) == generator.settings.tile:
-				var above: Vector2i = cell + Vector2i.UP
-				if grid.has_cell(above, layer) and grid.get_value(above, layer) != generator.settings.tile:
-					_temp_grid.set_value(cell, wall_tile)
+			print("Found ground?")
+
+			var above: Vector2i = cell + Vector2i.UP
+			if not _passes_filter(grid, above):
+				print("Found top of ground.")
+				_temp_grid.set_value(cell, wall_tile)
+
+			#if grid.get_value(cell, layer) == generator.settings.tile:
+				#var above: Vector2i = cell + Vector2i.UP
+				#if grid.has_cell(above, layer) and grid.get_value(above, layer) != generator.settings.tile:
+					#_temp_grid.set_value(cell, wall_tile)
 
 	generator.grid = _temp_grid.clone()
 	_temp_grid.unreference()

--- a/addons/gaea/renderers/2D/tilemap_gaea_renderer.gd
+++ b/addons/gaea/renderers/2D/tilemap_gaea_renderer.gd
@@ -101,6 +101,9 @@ func _draw_area(area: Rect2i) -> void:
 							terrains[tile_info] = [tile]
 						else:
 							terrains[tile_info].append(tile)
+					
+					TilemapTileInfo.Type.PATTERN:
+						_set_pattern(tile_position, tile_info)
 
 	for tile_info in terrains:
 		_set_terrain(terrains[tile_info], tile_info)
@@ -144,6 +147,14 @@ func _set_terrain(cells: Array, tile_info: TilemapTileInfo) -> void:
 					cells, tile_info.terrain_set, tile_info.terrain, !terrain_gap_fix
 				)
 
+func _set_pattern(cell:Vector2i, tile_info: TilemapTileInfo):
+	var layer:TileMapLayer = tile_map_layers[tile_info.tilemap_layer]
+	if (layer.tile_set.get_patterns_count() > tile_info.pattern_idx):
+		var pattern:TileMapPattern = layer.tile_set.get_pattern(tile_info.pattern_idx)
+		var position:Vector2i = cell + tile_info.pattern_offset
+		for x in range(pattern.get_size().x):
+			for y in range(pattern.get_size().y):
+				layer.set_pattern(position + Vector2i(x, y), pattern)
 
 func _get_tilemap_layers_count() -> int:
 	match node_type:

--- a/addons/gaea/renderers/2D/tilemap_gaea_renderer.gd
+++ b/addons/gaea/renderers/2D/tilemap_gaea_renderer.gd
@@ -152,9 +152,9 @@ func _set_pattern(cell:Vector2i, tile_info: TilemapTileInfo):
 	if (layer.tile_set.get_patterns_count() > tile_info.pattern_idx):
 		var pattern:TileMapPattern = layer.tile_set.get_pattern(tile_info.pattern_idx)
 		var position:Vector2i = cell + tile_info.pattern_offset
-		for x in range(pattern.get_size().x):
-			for y in range(pattern.get_size().y):
-				layer.set_pattern(position + Vector2i(x, y), pattern)
+		for tile in pattern.get_used_cells():
+			var pos = position + tile
+			layer.set_pattern(pos, pattern)
 
 func _get_tilemap_layers_count() -> int:
 	match node_type:


### PR DESCRIPTION
# Pattern Support
I noticed Gaea didn't have any support for Patterns, and figured it wouldn't be too too hard to implement.

## TilemapTileInfo
First off, this PR adds pattern_idx and pattern_offset properties to tilemap_tile_info.gd, as well as an extra Type enum entry. Lastly, it reworks the _validate_property method in a way that should make it easier to add more types in the future, should we want to.

## TilemapGaeaRenderer
Next, this PR adds support for the pattern type to tilemap_gaea_renderer.gd's _draw_area method. Note that other tile types and features like "Erase Empty Tiles" do interfere with it's output.

## Unroll Patterns Modifier
Since patterns won't be "painted" by the GaeaGenerator, this modifier makes it so that you can "unroll" them right in the grid data. This allows other modifiers such as Fill or Walls to function properly. It also avoids strange outputs from the renderer. To assist with this, GaiaGenerator2D now has a tile_pool array; the Unroll Patterns modifier needs to generate it's own TilemapTileInfo instances, so this pool helps with not making tons of identical copies of them.

## Walls Modifier
The Walls modifier failed to catch the unrolled pattern tiles, and this is because it bases it's target off of the settings.tile field. It has now been modified to simply rely on it's own Filters; it will detect a tile that is valid, then check if the tile above is invalid, at which point it will fill that tile.