### PR TITLE
Fix invalid world_size (y checking x) check in NoiseGenerator

### DIFF
--- a/addons/gaea/generators/2D/noise_generator/noise_generator.gd
+++ b/addons/gaea/generators/2D/noise_generator/noise_generator.gd
@@ -89,7 +89,7 @@ func _set_grid_area(rect: Rect2i) -> void:
 
 		for y in range(rect.position.y, rect.end.y):
 			if not settings.infinite:
-				if y < 0 or y > settings.world_size.x:
+				if y < 0 or y > settings.world_size.y:
 					continue
 
 			var noise = settings.noise.get_noise_2d(x, y)


### PR DESCRIPTION
Fix `_set_grid_area` using `settings.world_size.x` for `y` in `NoiseGenerator`