### PR TITLE
Remove wrong information from SnakePath2D description

### DIFF
--- a/addons/gaea/graph/nodes/root/data/generation/snake_path_2d.gd
+++ b/addons/gaea/graph/nodes/root/data/generation/snake_path_2d.gd
@@ -49,9 +49,7 @@ func get_data(output_port: int, area: AABB, generator_data: GaeaData) -> Diction
 		last_direction = direction
 		current_cell += direction
 
-	for x in get_axis_range(Axis.X, area):
-		for y in get_axis_range(Axis.Y, area):
-			if path.has(Vector2i(x, y)):
-				grid[Vector3i(x, y, 0)] = path.get(Vector2i(x, y))
+	for cell in path:
+		grid[Vector3i(cell.x, cell.y, 0)] = path.get(cell)
 
 	return grid

--- a/addons/gaea/graph/nodes/root/data/generation/snake_path_2d.tres
+++ b/addons/gaea/graph/nodes/root/data/generation/snake_path_2d.tres
@@ -87,8 +87,7 @@ input_slots = Array[ExtResource("2_a0dir")]([])
 args = Array[ExtResource("1_75iak")]([SubResource("Resource_5odk7"), SubResource("Resource_r83pm"), SubResource("Resource_2j7op"), SubResource("Resource_7hrwv"), SubResource("Resource_4yg0g"), SubResource("Resource_fpsoe"), SubResource("Resource_f1mpl"), SubResource("Resource_qr7np")])
 output_slots = Array[ExtResource("2_a0dir")]([SubResource("Resource_ci3aq")])
 title = "SnakePath2D"
-description = "Generates a path that goes from the top of the world to the bottom, with each cell consisting of flags that indicate their exits (up, down, left, right). 
-The rest is filled with 0s."
+description = "Generates a path that goes from the top of the world to the bottom, with each cell consisting of flags that indicate their exits (up, down, left, right). "
 is_output = false
 data = {}
 salt = 0


### PR DESCRIPTION
It said "The rest is filled with 0s" when that wasn't true.