### PR TITLE
Update TileMapGaeaRenderer and TileMapMaterial

### DIFF
--- a/addons/gaea/nodes/renderers/tilemap_renderer.gd
+++ b/addons/gaea/nodes/renderers/tilemap_renderer.gd
@@ -1,5 +1,5 @@
 @tool
-class_name TilemapGaeaRenderer
+class_name TileMapGaeaRenderer
 extends GaeaRenderer
 
 
@@ -7,13 +7,24 @@ extends GaeaRenderer
 
 
 func render(grid: GaeaGrid) -> void:
+	var terrains: Dictionary[TileMapMaterial, Array]
+
 	for layer_idx in grid.get_layers_count():
 		for cell in grid.get_layer(layer_idx):
 			var value = grid.get_layer(layer_idx)[cell]
-			if value is TilemapMaterial:
-				if tile_map_layers.size() <= layer_idx:
-					continue
-				tile_map_layers[layer_idx].set_cell(Vector2i(cell.x, cell.y), value.source_id, value.atlas_coord, value.alternative_tile)
+			if value is TileMapMaterial:
+				if value.type == TileMapMaterial.Type.SINGLE_CELL:
+					if tile_map_layers.size() <= layer_idx:
+						continue
+					tile_map_layers[layer_idx].set_cell(Vector2i(cell.x, cell.y), value.source_id, value.atlas_coord, value.alternative_tile)
+				elif value.type == TileMapMaterial.Type.TERRAIN:
+					terrains.get_or_add(value, []).append(Vector2(cell.x, cell.y))
+
+		for material: TileMapMaterial in terrains:
+			tile_map_layers[layer_idx].set_cells_terrain_connect(
+				terrains.get(material), material.terrain_set, material.terrain
+			)
+
 
 
 func _on_area_erased(area: AABB) -> void:

--- a/addons/gaea/resources/materials/tilemap_material.gd
+++ b/addons/gaea/resources/materials/tilemap_material.gd
@@ -1,5 +1,5 @@
 @tool
-class_name TilemapMaterial
+class_name TileMapMaterial
 extends GaeaMaterial
 ## Resource used to tell the generators which tile from a [TileMap] to place.
 


### PR DESCRIPTION
Allow using terrains in `TileMapGaeaRenderer` and also changes both the renderer and the material to use `TileMap` instead of `Tilemap`