### PR TITLE
Fix for Node Popup position breaking when the editor window is on a second monitor.

### DIFF
--- a/addons/gaea/editor/node_popup.gd
+++ b/addons/gaea/editor/node_popup.gd
@@ -54,7 +54,7 @@ func _on_id_pressed(id: int) -> void:
 			var node: GraphElement = selected.front()
 			if node is GraphFrame:
 				var popup: PopupPanel = PopupPanel.new()
-				popup.position = owner.get_global_mouse_position()
+				popup.position = owner.get_global_mouse_position() as Vector2i + DisplayServer.window_get_position()
 
 				var vbox_container: VBoxContainer = VBoxContainer.new()
 

--- a/addons/gaea/editor/panel.gd
+++ b/addons/gaea/editor/panel.gd
@@ -73,7 +73,7 @@ func _on_data_changed() -> void:
 
 
 func _popup_create_node_menu_at_mouse() -> void:
-	_create_node_popup.position = get_global_mouse_position()
+	_create_node_popup.position = get_global_mouse_position() as Vector2i + DisplayServer.window_get_position()
 	_create_node_popup.popup()
 
 
@@ -103,7 +103,7 @@ func _popup_context_menu_at_mouse(selected_nodes: Array) -> void:
 	_node_popup.clear()
 	_node_popup.populate(selected_nodes)
 
-	_node_popup.position = get_global_mouse_position()
+	_node_popup.position = get_global_mouse_position() as Vector2i + DisplayServer.window_get_position()
 	_node_popup.popup()
 
 


### PR DESCRIPTION
Quick fix, just needed to offset the global mouse position by the editor's window position in a few places.